### PR TITLE
增加 makedown 文件关联

### DIFF
--- a/Fcus/App.xaml.cs
+++ b/Fcus/App.xaml.cs
@@ -39,44 +39,7 @@ namespace Fcus
         /// <param name="e">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
-#if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                this.DebugSettings.EnableFrameRateCounter = true;
-            }
-#endif
-            Frame rootFrame = Window.Current.Content as Frame;
-
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (rootFrame == null)
-            {
-                // Create a Frame to act as the navigation context and navigate to the first page
-                rootFrame = new Frame();
-
-                rootFrame.NavigationFailed += OnNavigationFailed;
-
-                if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
-                {
-                    //TODO: Load state from previously suspended application
-                }
-
-                // Place the frame in the current Window
-                Window.Current.Content = rootFrame;
-            }
-
-            if (e.PrelaunchActivated == false)
-            {
-                if (rootFrame.Content == null)
-                {
-                    // When the navigation stack isn't restored navigate to the first page,
-                    // configuring the new page by passing required information as a navigation
-                    // parameter
-                    rootFrame.Navigate(typeof(MainPage), e.Arguments);
-                }
-                // Ensure the current window is active
-                Window.Current.Activate();
-            }
+            OnActivated(e);
         }
 
         /// <summary>
@@ -101,6 +64,59 @@ namespace Fcus
             var deferral = e.SuspendingOperation.GetDeferral();
             //TODO: Save application state and stop any background activity
             deferral.Complete();
+        }
+
+        protected override void OnActivated(IActivatedEventArgs args)
+        {
+#if DEBUG
+            if (System.Diagnostics.Debugger.IsAttached)
+            {
+                this.DebugSettings.EnableFrameRateCounter = true;
+            }
+#endif
+            Frame rootFrame = Window.Current.Content as Frame;
+
+            // Do not repeat app initialization when the Window already has content,
+            // just ensure that the window is active
+            if (rootFrame == null)
+            {
+                // Create a Frame to act as the navigation context and navigate to the first page
+                rootFrame = new Frame();
+
+                rootFrame.NavigationFailed += OnNavigationFailed;
+
+                if (args.PreviousExecutionState == ApplicationExecutionState.Terminated)
+                {
+                    //TODO: Load state from previously suspended application
+                }
+
+                // Place the frame in the current Window
+                Window.Current.Content = rootFrame;
+            }
+            var prelaunchActivated = false;
+
+
+            var launcharg = args as LaunchActivatedEventArgs;
+            if (launcharg != null)
+                prelaunchActivated = launcharg.PrelaunchActivated;
+            if(!prelaunchActivated)
+            {
+                // When the navigation stack isn't restored navigate to the first page,
+                // configuring the new page by passing required information as a navigation
+                var filearg = args as FileActivatedEventArgs;
+
+                if (filearg == null && rootFrame.Content == null)
+                    rootFrame.Navigate(typeof(MainPage));
+                else
+                    rootFrame.Navigate(typeof(MainPage), filearg.Files[0] as Windows.Storage.IStorageFile);
+                // Ensure the current window is active
+                Window.Current.Activate();
+            }
+
+        }
+        protected override void OnFileActivated(FileActivatedEventArgs args)
+        {
+            OnActivated(args);
         }
     }
 }

--- a/Fcus/MainPage.xaml
+++ b/Fcus/MainPage.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:Fcus"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    mc:Ignorable="d" >
     <Grid Background="#f5f5f5">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>

--- a/Fcus/Package.appxmanifest
+++ b/Fcus/Package.appxmanifest
@@ -26,9 +26,19 @@
           <uap:Rotation Preference="landscapeFlipped" />
         </uap:InitialRotationPreference>
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="makedown">
+            <uap:DisplayName>Markdown File</uap:DisplayName>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.md</uap:FileType>
+              <uap:FileType>.markdown</uap:FileType>
+              <uap:FileType>.mmd</uap:FileType>
+              <uap:FileType>.mdown</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
-  <Capabilities>
-    <uap:Capability Name="removableStorage" />
-  </Capabilities>
 </Package>


### PR DESCRIPTION
增加了对 makedown 文件的关联，可以直接双击使用该软件打开 md 文件
移除了不需要的“可移动存储”访问权限——使用文件打开选择器不需要该权限即可访问可移动存储